### PR TITLE
Sticky drawer not visible

### DIFF
--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -81,6 +81,8 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
             }];
             self.viewControllers = mutableViewControllers;
         }
+        self.masterViewState = BDBMasterViewStateHidden;
+        self.masterViewDisplayStyle = BDBMasterViewDisplayStyleNormal;
     }
     return self;
 }
@@ -267,7 +269,7 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
 #pragma mark Master View
 - (void)setMasterViewDisplayStyle:(BDBMasterViewDisplayStyle)style
 {
-    [self setMasterViewDisplayStyle:style animated:YES];
+    [self setMasterViewDisplayStyle:style animated:NO];
 }
 
 - (void)setMasterViewDisplayStyle:(BDBMasterViewDisplayStyle)style animated:(BOOL)animated
@@ -280,6 +282,7 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
         {
             self.detailViewShouldDim = NO;
             self.masterViewShouldDismissOnTap = NO;
+            self.masterViewState = BDBMasterViewStateVisible;
             break;
         }
 


### PR DESCRIPTION
Creating a splitview of type `BDBMasterViewDisplayStyleSticky` (init or by setting property) does not show the master view controller in either landscape or portrait modes.

The fix is to explicitly state the `masterViewState` and `masterViewDisplayStyles`, and then to set the `masterViewDisplayStyle` without animation. Also force the `masterViewState` flag to be visible for the sticky drawer.
