### PR TITLE
add preferredStatusBarStyle

### DIFF
--- a/BDBSplitViewController/BDBSplitViewController.h
+++ b/BDBSplitViewController/BDBSplitViewController.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, BDBMasterViewDisplayStyle)
 @property (nonatomic, assign) BOOL detailViewShouldDim;
 @property (nonatomic) CGFloat detailViewDimmingOpacity;
 
+@property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
 
 #pragma mark Initialization
 + (instancetype)splitViewWithMasterViewController:(UIViewController *)mvc detailViewController:(UIViewController *)dvc;


### PR DESCRIPTION
If you have dark navigation bars, then the status bar text is black-on-black.

```
[[UINavigationBar appearance] setBarStyle:UIBarStyleBlack];
```

By adding `preferredStatusBarStyle` to the split view controller, callers can specify light content.

```
BDBSplitViewController *splitViewController = [[BDBSplitViewController alloc] init...]
splitViewController.preferredStatusBarStyle = UIStatusBarStyleLightContent;
```
