### PR TITLE
KVO Fixing, Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,23 @@
+# OS X
 .DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
 xcuserdata
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# CocoaPods
+Pods

--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -145,13 +145,16 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if ([object isEqual:self.detailViewController] && [keyPath isEqualToString:@"view.frame"])
+    if (context == kBDBSplitViewKVOContext)
     {
-        UIView *view = self.detailViewController.view;
-        CGRect currentFrame = [change[@"new"] CGRectValue];
-        CGRect properFrame = [self detailViewFrameForState:self.masterViewState];
-        if (!CGRectEqualToRect(currentFrame, properFrame))
-            view.frame = [self detailViewFrameForState:self.masterViewState];
+        if ([object isEqual:self.detailViewController] && [keyPath isEqualToString:@"view.frame"])
+        {
+            UIView *view = self.detailViewController.view;
+            CGRect currentFrame = [change[@"new"] CGRectValue];
+            CGRect properFrame = [self detailViewFrameForState:self.masterViewState];
+            if (!CGRectEqualToRect(currentFrame, properFrame))
+                view.frame = [self detailViewFrameForState:self.masterViewState];
+        }
     }
     else
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -99,6 +99,12 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
     return self;
 }
 
+- (void)dealloc
+{
+    //Remove the observer to avoid KVO informations leakage error (NSKVODeallocateBreak)
+    [self.detailViewController removeObserver:self forKeyPath:@"view.frame" context:kBDBSplitViewKVOContext];
+}
+
 - (void)awakeFromNib
 {
     [super awakeFromNib];


### PR DESCRIPTION
The main goal of this PR is to fix the following error on dealloc

```
An instance 0x1272d3e0 of class UINavigationController was deallocated while key value observers were still registered with it. Observation info was leaked, and may even become mistakenly attached to some other object. Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger. Here's the current observation info:
<NSKeyValueObservationInfo 0x1270e9c0> (
<NSKeyValueObservance 0x1270e8d0: Observer: 0x12728ce0, Key path: view.frame, Options: <New: YES, Old: YES, Prior: NO> Context: 0x508f38, Property: 0x1270eb80>
)
```

I also updated the gitignore to github standard, and testing for context in KVO observeValueForKeyPath:ofObject:... method.

Thanks for the lib, working great for me so far
