### PR TITLE
Fix shadow in DisplayStyleDrawer Theme.

### DIFF
--- a/BDBSplitViewController/BDBSplitViewController.m
+++ b/BDBSplitViewController/BDBSplitViewController.m
@@ -186,6 +186,7 @@ static void * const kBDBSplitViewKVOContext = (void *)&kBDBSplitViewKVOContext;
         self.masterViewController.view.layer.shadowOffset = (CGSize){0, 0};
         self.masterViewController.view.layer.shadowRadius = 10.0;
         self.masterViewController.view.layer.shadowOpacity = 0.8;
+        self.masterViewController.view.alpha = 0.0;
     }
     else
     {


### PR DESCRIPTION
When you use DisplayStyleDrawer theme for first time the shadow of masterView is not hidden.

```
BDBSplitViewController *splitViewController = [[BDBSplitViewController alloc] initWithMasterViewController:[MasterViewController new]
                                                                                      detailViewController:[[DrawerDetailViewController alloc] initWithNibName:nil bundle:nil]];
```

Before: 
![screen shot 2014-03-11 at 5 11 01](https://f.cloud.github.com/assets/1813468/2381144/eaa43c9a-a8bb-11e3-9ab2-ac2c3068c20b.png)

After: 
![screen shot 2014-03-11 at 5 24 13](https://f.cloud.github.com/assets/1813468/2381146/f8e2650c-a8bb-11e3-8b51-acc14ccf1ed4.png)
